### PR TITLE
Display "Controlling Animations" header properly

### DIFF
--- a/pages/v3/Working-With-Animations.md
+++ b/pages/v3/Working-With-Animations.md
@@ -40,7 +40,8 @@ Pressing play, you will see the full animation running, slowly.
 
 By tweaking the values in AnimSpriteRenderer, you can control the animation speed, when it starts, when it ends, if it starts automatically, etc.
 
-#Controlling Animations
+# Controlling Animations
+
 So, knowing now how to create an animated character, we need to slice the spritesheet into the various segments, like walking, jumping, running, etc.
 
 Our example has two segments that we must define so that our character doesn't just loop through every frame in the animation nonstop.


### PR DESCRIPTION
Add a space between the hash and the text so it doesn't look like "#Controlling Animations".

GitHub Pages headers need a space between the hash and the text or they just display "#text". This just adds a space. Yay!

# Before:

![image](https://user-images.githubusercontent.com/5149181/51435325-8e254980-1c3a-11e9-9c0d-3c2826720d17.png)

# After:

![image](https://user-images.githubusercontent.com/5149181/51435335-bdd45180-1c3a-11e9-9cfe-77922fdd54a0.png)
