### PR TITLE
Updated copyright note in license info

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Fedja Adam
+Copyright (c) 2020 The Duality Core Team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The LICENSE note still stated I had the copyright on Duality, dated 2018. I'd like to remove my name from this entirely, replacing it with a reference to the core team and an updated timestamp.

Actually the same as [this one](https://github.com/AdamsLair/duality/pull/837) on the main repo, just mirrored for docs.